### PR TITLE
initial import of command-line / env argument for network type

### DIFF
--- a/apps/example/lib/app_config.dart
+++ b/apps/example/lib/app_config.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+/// Global application configuration.
+/// Call [AppConfig.initialize] once at startup before runApp().
+class AppConfig {
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Network modes
+  static const int mainnet = 0;
+  static const int testnet = 1;
+  static const int stagenet = 2;
+
+  static bool _isInitialized = false;
+  static late final int network;      // 0=mainnet, 1=testnet, 2=stagenet
+  static late final String modeString;
+  static late final int rpcPort;
+  static late final String rpcAddress;
+
+  static bool get isInitialized => _isInitialized;
+  static bool get isMainnet => network == mainnet;
+  static bool get isTestnet => network == testnet;
+  static bool get isStagenet => network == stagenet;
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  /// Initializes configuration based on CLI args or environment variable APP_MODE.
+  static Future<void> initialize(List<String> args) async {
+    if (_isInitialized) return;
+
+    String? detectedMode;
+
+    // 1️⃣ Try CLI argument
+    if (args.isNotEmpty) {
+      detectedMode = args.first.trim().toLowerCase();
+      stdout.writeln("Command-line arg found: $detectedMode");
+    } else {
+      // 2️⃣ Fallback to environment variable
+      detectedMode = Platform.environment['APP_MODE']?.toLowerCase();
+      if (detectedMode != null) {
+        stdout.writeln("Environment variable found: $detectedMode");
+      } else {
+        stdout.writeln("No mode specified — defaulting to mainnet");
+      }
+    }
+
+    // 3️⃣ Normalize and assign network parameters
+    switch (detectedMode) {
+      case 'testnet':
+        network = testnet;
+        modeString = 'testnet';
+        rpcPort = 29081;
+        break;
+      case 'stagenet':
+        network = stagenet;
+        modeString = 'stagenet';
+        rpcPort = 39081;
+        break;
+      case 'mainnet':
+      default:
+        network = mainnet;
+        modeString = 'mainnet';
+        rpcPort = 19081;
+    }
+
+    // 4️⃣ Construct RPC address (can easily extend later)
+    rpcAddress = "localhost:$rpcPort";
+
+    _isInitialized = true;
+
+    stdout.writeln("🌐 Network mode: $modeString ($network)");
+    stdout.writeln("🔌 RPC endpoint: $rpcAddress");
+  }
+}

--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:cs_salvium/cs_salvium.dart';
 import 'package:cs_salvium_flutter_libs/cs_salvium_flutter_libs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'app_config.dart';
 
 import 'views/create_view_only_wallet_view.dart';
 import 'views/create_wallet_view.dart';
@@ -13,7 +14,11 @@ import 'views/restore_deterministic_from_spend_key_view.dart';
 import 'views/restore_from_keys_view.dart';
 import 'views/restore_from_seed_view.dart';
 
-void main() async {
+Future<void> main(List<String> args) async {
+
+  // Initialize config before launching app
+  await AppConfig.initialize(args);
+
   WidgetsFlutterBinding.ensureInitialized();
 
   Logging.useLogger = true;

--- a/apps/example/lib/views/open_wallet_view.dart
+++ b/apps/example/lib/views/open_wallet_view.dart
@@ -1,6 +1,7 @@
 import 'package:cs_salvium/cs_salvium.dart';
 import 'package:flutter/material.dart';
 
+import '../app_config.dart';
 import '../util.dart';
 import 'wallet_view.dart';
 
@@ -108,21 +109,13 @@ class _OpenWalletDialogState extends State<OpenWalletDialog> {
     final String daemonAddress;
     switch (type) {
       case "salvium":
-        daemonAddress = "localhost:29081"; // seed01.salvium.io seed02.salvium.io seed03.salvium.io
+        daemonAddress = AppConfig.rpcAddress;
         wallet = await SalviumWallet.loadWallet(
           path: path,
           password: pw,
-          networkType: 1 // testnet
+          networkType: AppConfig.network,
         );
         break;
-
-      // case "wownero":
-      //   daemonAddress = "wownero.stackwallet.com:34568";
-      //   wallet = await WowneroWallet.loadWallet(
-      //     path: path,
-      //     password: pw,
-      //   );
-      //   break;
 
       default:
         throw Exception("Unknown wallet type: $type");

--- a/apps/example/lib/views/wallet_view.dart
+++ b/apps/example/lib/views/wallet_view.dart
@@ -1,6 +1,7 @@
 import 'package:cs_salvium/cs_salvium.dart';
 import 'package:flutter/material.dart';
 
+import '../app_config.dart';
 import '../widgets/info_item.dart';
 import 'create_transaction_view.dart';
 import 'create_stake_view.dart';
@@ -195,6 +196,7 @@ class _WalletViewState extends State<WalletView> {
             child: ListView(
               shrinkWrap: true,
               children: [
+                InfoItem(label: "Network Type", value: AppConfig.modeString),
                 InfoItem(label: "Is view only", value: isViewOnly),
                 InfoItem(label: "Connected", value: connected),
                 InfoItem(label: "outputCount", value: outputCount),

--- a/packages/cs_salvium/lib/src/wallet.dart
+++ b/packages/cs_salvium/lib/src/wallet.dart
@@ -403,7 +403,7 @@ abstract class Wallet {
   /// Create a single recipient transaction.
   ///
   /// Returns a [PendingTransaction], required for [commitTx].
-  Future<PendingTransaction> stakeTx({
+  Future<PendingTransaction> createStakeTx({
     required Recipient output,
     required TransactionPriority priority,
     required int accountIndex,

--- a/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
+++ b/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
@@ -1179,7 +1179,7 @@ class SalviumWallet extends Wallet {
   }
 
   @override
-  Future<PendingTransaction> stakeTx({
+  Future<PendingTransaction> createStakeTx({
     required Recipient output,
     required TransactionPriority priority,
     required int accountIndex,


### PR DESCRIPTION
Add command-line argument and env string support for setting the network mode to test in.

Example use: `APP_MODE=testnet flutter run -d linux`

Supported values:

- `mainnet = 0`
- `testnet = 1`
- `stagenet = 2`